### PR TITLE
Add more case modifiers

### DIFF
--- a/docs/structure/variables/modifiers.md
+++ b/docs/structure/variables/modifiers.md
@@ -15,6 +15,7 @@ it, separated by a colon (`:`). The arguments are specified inside of braces whi
 ```
 %% pusta.hostname:contains("laptop-") %%
 %% pusta.hostname:case-upper %%
+%% pusta.hostname:case-snake("case-kebab") %%
 ```
 
 Modifiers can be chained and take other variables with modifiers as parameters, to create some more interesting results:
@@ -35,6 +36,10 @@ The following modifiers are currently available. A modifier listed under its *na
 | `contains`       | *string*    | *string*       | gives a *boolean* `true` if the variable contains the parameter                                                        |
 | `case-upper`     | *string*    |                | converts the variable to upper case                                                                                    |
 | `case-lower`     | *string*    |                | converts the variable to lower case                                                                                    |
+| `case-camel`     | *string*    | *string*       | converts the variable from the parameter case to camel case                                                            |
+| `case-snake`     | *string*    | *string*       | converts the variable from the parameter case to snake case                                                            |
+| `case-pascal`    | *string*    | *string*       | converts the variable from the parameter case to pascal case                                                           |
+| `case-kebab`     | *string*    | *string*       | converts the variable from the parameter case to kebab case                                                            |
 | `tilde`          | *string*    |                | expands the `~` in the given string to the user's home directory                                                       |
 | `parsenum`       | *string*    |                | parses the variable from string to a number                                                                            |
 | `not`            | *boolean*   |                | inverts the boolean value of the variable                                                                              |

--- a/src/variables/modifier/mod.rs
+++ b/src/variables/modifier/mod.rs
@@ -4,7 +4,7 @@ mod number;
 
 use number::{ParseNumberModifier, PARSE_NUMBER_MODIFIER};
 use regex::Regex;
-use string::{ShellexpandModifier, SHELLEXPAND_MODIFIER};
+use string::{CamelCaseModifier, KebabCaseModifier, PascalCaseModifier, ShellexpandModifier, SnakeCaseModifier, CAMEL_CASE_MODIFIER, KEBAB_CASE_MODIFIER, PASCAL_CASE_MODIFIER, SHELLEXPAND_MODIFIER, SNAKE_CASE_MODIFIER};
 use crate::variables::{Value, VariableError};
 use crate::variables::context::{Expression, ExpressionModifier};
 use crate::variables::modifier::boolean::{NOT_MODIFIER, AND_MODIFIER, OR_MODIFIER, IF_MODIFIER, NotModifier, AndModifier, OrModifier, IfModifier};
@@ -118,6 +118,10 @@ pub fn get_modifier(name: &str) -> Option<Box<dyn Modifier>> {
     Some(match name {
         UPPER_CASE_MODIFIER => { Box::new(UpperCaseModifier) }
         LOWER_CASE_MODIFIER => { Box::new(LowerCaseModifier) }
+        CAMEL_CASE_MODIFIER => { Box::new(CamelCaseModifier) }
+        SNAKE_CASE_MODIFIER => { Box::new(SnakeCaseModifier) }
+        PASCAL_CASE_MODIFIER => { Box::new(PascalCaseModifier) }
+        KEBAB_CASE_MODIFIER => { Box::new(KebabCaseModifier) }
         CONTAINS_MODIFIER => { Box::new(ContainsModifier) }
         SHELLEXPAND_MODIFIER => { Box::new(ShellexpandModifier) }
 

--- a/src/variables/modifier/string.rs
+++ b/src/variables/modifier/string.rs
@@ -11,9 +11,7 @@ pub const UPPER_CASE_MODIFIER: &str = "case-upper";
 impl Modifier for UpperCaseModifier {
     fn evaluate(&self, variable: Value, parameters: Vec<Value>) -> Result<Value, ModifierError> {
         // Expects no parameters
-        if !parameters.is_empty() {
-            return Err(ModifierError::simple(ParameterAmount(0)));
-        }
+        if !parameters.is_empty() { return Err(ModifierError::simple(ParameterAmount(0))); }
 
         // Evaluate
         match variable {
@@ -29,9 +27,7 @@ pub const LOWER_CASE_MODIFIER: &str = "case-lower";
 impl Modifier for LowerCaseModifier {
     fn evaluate(&self, variable: Value, parameters: Vec<Value>) -> Result<Value, ModifierError> {
         // Expects no parameters
-        if !parameters.is_empty() {
-            return Err(ModifierError::simple(ParameterAmount(0)));
-        }
+        if !parameters.is_empty() { return Err(ModifierError::simple(ParameterAmount(0))); }
 
         // Evaluate
         match variable {
@@ -89,9 +85,7 @@ pub struct CamelCaseModifier;
 pub const CAMEL_CASE_MODIFIER: &str = "case-camel";
 impl Modifier for CamelCaseModifier {
     fn evaluate(&self, variable: Value, parameters: Vec<Value>) -> Result<Value, ModifierError> {
-        if parameters.len() != 1 {
-            return Err(ModifierError::simple(ParameterAmount(1)));
-        }
+        if parameters.len() != 1 { Err(ModifierError::simple(ParameterAmount(1)))? }
 
         match (variable, &parameters[0]) {
             (String(s), String(c)) => {

--- a/src/variables/modifier/string.rs
+++ b/src/variables/modifier/string.rs
@@ -1,7 +1,9 @@
-use crate::variables::modifier::{Modifier, ModifierError};
 use crate::variables::modifier::ModifierErrorType::{ParameterAmount, ParameterType, VariableType};
+use crate::variables::modifier::{Modifier, ModifierError};
 use crate::variables::Value;
 use crate::variables::Value::{Boolean, String};
+
+use super::ModifierErrorNote;
 
 /// This modifier converts a string to upper case
 pub struct UpperCaseModifier;
@@ -9,14 +11,14 @@ pub const UPPER_CASE_MODIFIER: &str = "case-upper";
 impl Modifier for UpperCaseModifier {
     fn evaluate(&self, variable: Value, parameters: Vec<Value>) -> Result<Value, ModifierError> {
         // Expects no parameters
-        if !parameters.is_empty() { return Err(ModifierError::simple(ParameterAmount(0))); }
+        if !parameters.is_empty() {
+            return Err(ModifierError::simple(ParameterAmount(0)));
+        }
 
         // Evaluate
         match variable {
-            String(s) => {
-                Ok(String(s.to_uppercase()))
-            }
-            _ => { Err(ModifierError::simple(VariableType(String("".into())))) }
+            String(s) => Ok(String(s.to_uppercase())),
+            _ => Err(ModifierError::simple(VariableType(String("".into())))),
         }
     }
 }
@@ -27,14 +29,163 @@ pub const LOWER_CASE_MODIFIER: &str = "case-lower";
 impl Modifier for LowerCaseModifier {
     fn evaluate(&self, variable: Value, parameters: Vec<Value>) -> Result<Value, ModifierError> {
         // Expects no parameters
-        if !parameters.is_empty() { return Err(ModifierError::simple(ParameterAmount(0))); }
+        if !parameters.is_empty() {
+            return Err(ModifierError::simple(ParameterAmount(0)));
+        }
 
         // Evaluate
         match variable {
-            String(s) => {
-                Ok(String(s.to_lowercase()))
+            String(s) => Ok(String(s.to_lowercase())),
+            _ => Err(ModifierError::simple(VariableType(String("".into())))),
+        }
+    }
+}
+
+/// Turn a string into it's case segments based on an origin case
+///
+/// The segments are returned as a vector of lower-cased strings
+fn into_case_segments(
+    s: std::string::String,
+    case: &str,
+) -> Result<Vec<std::string::String>, std::string::String> {
+    let segments = match case {
+        KEBAB_CASE_MODIFIER => s.to_lowercase().split("-").map(std::string::String::from).collect(),
+        SNAKE_CASE_MODIFIER => s.to_lowercase().split("_").map(std::string::String::from).collect(),
+        CAMEL_CASE_MODIFIER | PASCAL_CASE_MODIFIER => {
+            let mut c = s.chars();
+            // uppercase first letter to transform camelCase to PascalCase
+            let s = match c.next() {
+                None => std::string::String::new(),
+                Some(f) => f.to_uppercase().chain(c).collect(),
+            };
+
+            let mut previous_upper = true;
+            let mut start = 0;
+            let mut segments = Vec::new();
+
+            if s.len() == 1 {
+                return Ok(vec![s.to_lowercase()]);
             }
-            _ => { Err(ModifierError::simple(VariableType(String("".into())))) }
+
+            s[1..].chars().enumerate().for_each(|(i, c)| {
+                if c.is_uppercase() {
+                    segments.push(s[start..i+1].to_lowercase());
+                    start = i + 1;
+                } else if c.is_lowercase() && previous_upper {
+                    previous_upper = false;
+                }
+                if i == s.len() - 2 {
+                    segments.push(s[start..i+2].to_lowercase())
+                }
+            });
+            segments
+        }
+        _ => Err(format!("case '{case}' is not a valid origin case"))?,
+    };
+    Ok(segments)
+}
+
+pub struct CamelCaseModifier;
+pub const CAMEL_CASE_MODIFIER: &str = "case-camel";
+impl Modifier for CamelCaseModifier {
+    fn evaluate(&self, variable: Value, parameters: Vec<Value>) -> Result<Value, ModifierError> {
+        if parameters.len() != 1 {
+            return Err(ModifierError::simple(ParameterAmount(1)));
+        }
+
+        match (variable, &parameters[0]) {
+            (String(s), String(c)) => {
+                let mut segments = into_case_segments(s, c.as_str()).map_err(|err| {
+                    ModifierError::noted(
+                        ParameterType(0, String("".into())),
+                        vec![ModifierErrorNote::Parameter(0, err)],
+                    )
+                })?.into_iter();
+                let first = segments.next().unwrap_or_default();
+                let rest = segments.map(|seg| {
+                    let mut c = seg.chars();
+                    match c.next() {
+                        None => std::string::String::new(),
+                        Some(f) => f.to_uppercase().chain(c).collect(),
+                    }
+                }).collect::<Vec<_>>().join("");
+                Ok(String(first + rest.as_str()))
+            }
+            (String(_), _) => Err(ModifierError::simple(ParameterType(0, String("".into())))),
+            _ => Err(ModifierError::simple(VariableType(String("".into())))),
+        }
+    }
+}
+
+pub struct SnakeCaseModifier;
+pub const SNAKE_CASE_MODIFIER: &str = "case-snake";
+impl Modifier for SnakeCaseModifier {
+    fn evaluate(&self, variable: Value, parameters: Vec<Value>) -> Result<Value, ModifierError> {
+        if parameters.len() != 1 { Err(ModifierError::simple(ParameterAmount(1)))? }
+
+        match (variable, &parameters[0]) {
+            (String(s), String(c)) => {
+                let segments = into_case_segments(s, c.as_str()).map_err(|err| {
+                    ModifierError::noted(
+                        ParameterType(0, String("".into())),
+                        vec![ModifierErrorNote::Parameter(0, err)],
+                    )
+                })?;
+                Ok(String(segments.join("_")))
+            }
+            (String(_), _) => Err(ModifierError::simple(ParameterType(0, String("".into())))),
+            _ => Err(ModifierError::simple(VariableType(String("".into())))),
+        }
+    }
+}
+
+pub struct PascalCaseModifier;
+pub const PASCAL_CASE_MODIFIER: &str = "case-pascal";
+impl Modifier for PascalCaseModifier {
+    fn evaluate(&self, variable: Value, parameters: Vec<Value>) -> Result<Value, ModifierError> {
+        if parameters.len() != 1 { Err(ModifierError::simple(ParameterAmount(1)))? }
+
+        match (variable, &parameters[0]) {
+            (String(s), String(c)) => {
+                let segments = into_case_segments(s, c.as_str()).map_err(|err| {
+                    ModifierError::noted(
+                        ParameterType(0, String("".into())),
+                        vec![ModifierErrorNote::Parameter(0, err)],
+                    )
+                })?;
+                let str = segments.iter().map(|seg| {
+                    let mut c = seg.chars();
+                    match c.next() {
+                        None => std::string::String::new(),
+                        Some(f) => f.to_uppercase().chain(c).collect(),
+                    }
+                }).collect::<Vec<_>>().join("");
+                Ok(String(str))
+            }
+            (String(_), _) => Err(ModifierError::simple(ParameterType(0, String("".into())))),
+            _ => Err(ModifierError::simple(VariableType(String("".into())))),
+        }
+    }
+}
+
+pub struct KebabCaseModifier;
+pub const KEBAB_CASE_MODIFIER: &str = "case-kebab";
+impl Modifier for KebabCaseModifier {
+    fn evaluate(&self, variable: Value, parameters: Vec<Value>) -> Result<Value, ModifierError> {
+        if parameters.len() != 1 { Err(ModifierError::simple(ParameterAmount(1)))? }
+
+        match (variable, &parameters[0]) {
+            (String(s), String(c)) => {
+                let segments = into_case_segments(s, c.as_str()).map_err(|err| {
+                    ModifierError::noted(
+                        ParameterType(0, String("".into())),
+                        vec![ModifierErrorNote::Parameter(0, err)],
+                    )
+                })?;
+                Ok(String(segments.join("-")))
+            }
+            (String(_), _) => Err(ModifierError::simple(ParameterType(0, String("".into())))),
+            _ => Err(ModifierError::simple(VariableType(String("".into())))),
         }
     }
 }
@@ -101,6 +252,82 @@ mod test {
     }
 
     #[test]
+    fn camel() {
+        let modifier = get_modifier("case-camel").unwrap();
+
+        assert_eq!(String("thisIsCamelCase".to_string()), modifier.evaluate(String("thisIsCamelCase".to_string()), vec![String("case-camel".to_string())]).unwrap());
+        assert_eq!(String("thisIsCamelCase".to_string()), modifier.evaluate(String("this_is_camel_case".to_string()), vec![String("case-snake".to_string())]).unwrap());
+        assert_eq!(String("thisIsCamelCase".to_string()), modifier.evaluate(String("ThisIsCamelCase".to_string()), vec![String("case-pascal".to_string())]).unwrap());
+        assert_eq!(String("thisIsCamelCase".to_string()), modifier.evaluate(String("this-is-camel-case".to_string()), vec![String("case-kebab".to_string())]).unwrap());
+
+        assert_eq!(String("p".to_string()), modifier.evaluate(String("P".to_string()), vec![String("case-pascal".to_string())]).unwrap());
+        assert_eq!(String("pP".to_string()), modifier.evaluate(String("PP".to_string()), vec![String("case-pascal".to_string())]).unwrap());
+
+        // require exactly one parameter
+        assert!(modifier.evaluate(String("thisIsCamelCase".to_string()), vec![]).is_err());
+        assert!(modifier.evaluate(String("thisIsCamelCase".to_string()), vec![String("".into()), String("".into())]).is_err());
+        // parameter needs to be a well-known case type
+        assert!(modifier.evaluate(String("thisIsCamelCase".to_string()), vec![String("".into())]).is_err());
+    }
+
+    #[test]
+    fn snake() {
+        let modifier = get_modifier("case-snake").unwrap();
+
+        assert_eq!(String("this_is_snake_case".to_string()), modifier.evaluate(String("thisIsSnakeCase".to_string()), vec![String("case-camel".to_string())]).unwrap());
+        assert_eq!(String("this_is_snake_case".to_string()), modifier.evaluate(String("this_is_snake_case".to_string()), vec![String("case-snake".to_string())]).unwrap());
+        assert_eq!(String("this_is_snake_case".to_string()), modifier.evaluate(String("ThisIsSnakeCase".to_string()), vec![String("case-pascal".to_string())]).unwrap());
+        assert_eq!(String("this_is_snake_case".to_string()), modifier.evaluate(String("this-is-snake-case".to_string()), vec![String("case-kebab".to_string())]).unwrap());
+
+        assert_eq!(String("p".to_string()), modifier.evaluate(String("P".to_string()), vec![String("case-pascal".to_string())]).unwrap());
+        assert_eq!(String("p_p".to_string()), modifier.evaluate(String("PP".to_string()), vec![String("case-pascal".to_string())]).unwrap());
+
+        // require exactly one parameter
+        assert!(modifier.evaluate(String("this_is_snake_case".to_string()), vec![]).is_err());
+        assert!(modifier.evaluate(String("this_is_snake_case".to_string()), vec![String("".into()), String("".into())]).is_err());
+        // parameter needs to be a well-known case type
+        assert!(modifier.evaluate(String("this_is_snake_case".to_string()), vec![String("".into())]).is_err());
+    }
+
+    #[test]
+    fn pascal() {
+        let modifier = get_modifier("case-pascal").unwrap();
+
+        assert_eq!(String("ThisIsPascalCase".to_string()), modifier.evaluate(String("thisIsPascalCase".to_string()), vec![String("case-camel".to_string())]).unwrap());
+        assert_eq!(String("ThisIsPascalCase".to_string()), modifier.evaluate(String("this_is_pascal_case".to_string()), vec![String("case-snake".to_string())]).unwrap());
+        assert_eq!(String("ThisIsPascalCase".to_string()), modifier.evaluate(String("ThisIsPascalCase".to_string()), vec![String("case-pascal".to_string())]).unwrap());
+        assert_eq!(String("ThisIsPascalCase".to_string()), modifier.evaluate(String("this-is-pascal-case".to_string()), vec![String("case-kebab".to_string())]).unwrap());
+
+        assert_eq!(String("P".to_string()), modifier.evaluate(String("p".to_string()), vec![String("case-camel".to_string())]).unwrap());
+        assert_eq!(String("PP".to_string()), modifier.evaluate(String("pP".to_string()), vec![String("case-camel".to_string())]).unwrap());
+
+        // require exactly one parameter
+        assert!(modifier.evaluate(String("ThisIsPascalCase".to_string()), vec![]).is_err());
+        assert!(modifier.evaluate(String("ThisIsPascalCase".to_string()), vec![String("".into()), String("".into())]).is_err());
+        // parameter needs to be a well-known case type
+        assert!(modifier.evaluate(String("ThisIsPascalCase".to_string()), vec![String("".into())]).is_err());
+    }
+
+    #[test]
+    fn kebab() {
+        let modifier = get_modifier("case-kebab").unwrap();
+
+        assert_eq!(String("this-is-kebab-case".to_string()), modifier.evaluate(String("thisIsKebabCase".to_string()), vec![String("case-camel".to_string())]).unwrap());
+        assert_eq!(String("this-is-kebab-case".to_string()), modifier.evaluate(String("this_is_kebab_case".to_string()), vec![String("case-snake".to_string())]).unwrap());
+        assert_eq!(String("this-is-kebab-case".to_string()), modifier.evaluate(String("ThisIsKebabCase".to_string()), vec![String("case-pascal".to_string())]).unwrap());
+        assert_eq!(String("this-is-kebab-case".to_string()), modifier.evaluate(String("this-is-kebab-case".to_string()), vec![String("case-kebab".to_string())]).unwrap());
+
+        assert_eq!(String("p".to_string()), modifier.evaluate(String("p".to_string()), vec![String("case-camel".to_string())]).unwrap());
+        assert_eq!(String("p-p".to_string()), modifier.evaluate(String("pP".to_string()), vec![String("case-camel".to_string())]).unwrap());
+
+        // require exactly one parameter
+        assert!(modifier.evaluate(String("this-is-kebab-case".to_string()), vec![]).is_err());
+        assert!(modifier.evaluate(String("this-is-kebab-case".to_string()), vec![String("".into()), String("".into())]).is_err());
+        // parameter needs to be a well-known case type
+        assert!(modifier.evaluate(String("this-is-kebab-case".to_string()), vec![String("".into())]).is_err());
+    }
+
+    #[test]
     fn contains() {
         let modifier = get_modifier("contains").unwrap();
 
@@ -116,7 +343,6 @@ mod test {
 
     #[test]
     fn tilde() {
-
         let modifier = get_modifier("tilde").unwrap();
 
         // valid
@@ -127,5 +353,4 @@ mod test {
         assert!(matches!(modifier.evaluate(Boolean(false), vec![]), Err(_)));
         assert!(matches!(modifier.evaluate(String("asdf".to_string()), vec![Boolean(true)]), Err(_)));
     }
-
 }


### PR DESCRIPTION
This adds the following new string modifiers:
- `case-camel(case)`: Turn the string which is currently in *case* into camel case
- `case-snake(case)`: Turn the string which is currently in *case* into snake case
- `case-pascal(case)`: Turn the string which is currently in *case* into pascal case
- `case-kebab(case)`: Turn the string which is currently in *case* into kebab case